### PR TITLE
Don't send -0 for heat when cooling and vice versa

### DIFF
--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -333,9 +333,13 @@ class NexiaThermostat {
   handleTargetTemperatureSet(value: any, callback: (arg0: null) => void) {
     this.log.debug('Triggered SET TargetTemperature:' + value);
     this.computeState((state: { heatingSetpoint: any; coolingSetpoint: any; mappedMode: any; setPointUrl: string, scale: number }) => {
+
+      const targetHeatingTemperature = this.convertTemperature(this.currentTemperatureScale, state.scale, state.heatingSetpoint);
+      const targetCoolingTemperature = this.convertTemperature(this.currentTemperatureScale, state.scale, state.coolingSetpoint);
+
       const payload = { 
-        heat: this.convertTemperature(this.currentTemperatureScale, state.scale, state.heatingSetpoint), 
-        cool: this.convertTemperature(this.currentTemperatureScale, state.scale, state.coolingSetpoint) 
+        heat: targetHeatingTemperature === 0 ? null : targetHeatingTemperature,
+        cool: targetCoolingTemperature === 0 ? null : targetCoolingTemperature
       }
       const thermostatTemperature = this.convertTemperature(this.currentTemperatureScale, state.scale, value);
       if (state.mappedMode == this.Characteristic.CurrentHeatingCoolingState.HEAT) {


### PR DESCRIPTION
An extension on the previous commit. I'm not sure if this bug is unique to me or my system, but this is what I've identified during `handleTargetHeatingCoolingStateSet`:

If I'm following the code correctly, temperature setpoints seem to get converted from F (from the API) to C (plugin state) and then back to F (for the outgoing requests). I identified that when setting a `heat` setpoint, it tries to send a `-0` for the `cool` setpoint. The API replies with a 200, but the call seems to be ignored because of the `-0`. I think this is not being caught by logic the previous commit because the plugin state is in C, so the temp being checked holds a value of -17.8, not 0.

To try to get scale out of the picture, I am now checking for the 0 after it has been converted back to F, just before the request goes out. I don't know enough about the Trane API to know if their APIs can accept or provide temps in C. I'm making an educated guess a 0 setpoint would not be accepted by the API in both C and F, and if so, this should cover both scales.

Let me know if you'd prefer I implement this in a different way. Thanks!